### PR TITLE
updated contact page link

### DIFF
--- a/index.md
+++ b/index.md
@@ -13,4 +13,4 @@ introduction to PittMesh and mesh networking in general, please view our
 PittMesh currently has <span id="live">#</span> nodes hoisted. <span id="planned"> </span> Live connectivity data coming soon.
 
 Want to help build the future of connectivity in Pittsburgh?
-[Contact Meta Mesh.](http://www.metamesh.org/contact.html)
+[Contact Meta Mesh.](http://www.metamesh.org/#!contact-meta-mesh/c24vq)


### PR DESCRIPTION
The contact page link lead just to our homepage. I've resolved this by adding the new link in. http://www.metamesh.org/#!contact-meta-mesh/c24vq