### PR TITLE
changed events page to meetup.com

### DIFF
--- a/_includes/side_nav.haml
+++ b/_includes/side_nav.haml
@@ -1,7 +1,7 @@
 %header
   %nav
     .link
-      %a{ href: '/events.html' }
+      %a{ href: 'www.meetup.com/pittmeshworkinggroup/' }
         Upcoming Events
     .link
       %a{ href: '/ipcalc' }


### PR DESCRIPTION
We never update this events page. Meetup.com's PWG site is better for this sort of thing so let's use that.