### PR TITLE
Use heroku's release phase instead of Travis's run

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,5 +25,4 @@ deploy:
   app: pittmesh-net
   api_key:
     secure: N5EE2AXgflG/0AvkX/DdBpZrapV57lfiTqtgwGHKip722nhvytoRzHjNr1+qKs/03A1YJnxmA6RcS7C5tCmgdLzTCfYBa3SdXaq/qUV7fimQxG6VC3Xum04Oc8T7+hY7lRGyg6oCNKVZ35G2Wk9i9vu/sqO4ePSmJFiG3vnOHKk=
-  run:
-    - ./_script/pittmesh_nodes_to_geojson.sh node-data/nodes.json > node-data/nodes.geojson
+

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,3 @@
 #web:	jekyll --server $PORT
+release: _script/pittmesh_nodes_to_geojson.sh node-data/nodes.json > node-data/nodes.geojson
 web: bundle exec rackup config.ru -p $PORT


### PR DESCRIPTION
We were hitting a race condition when the commands executed by run would start
milliseconds before the web process started, but not complete before the web
process had read from the node-data directory.