### PR TITLE
Adds Jekyll hook that generates the geojson file

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gem 'jekyll-haml'
 gem 'haml-contrib'  #, :require => 'haml/filters/maruku'
 
 group :development do
+  gem 'pry'
   gem 'html-proofer'
   gem 'rake'
   gem 'mr_poole' #quick way to generate posts: poole post "Title" | editor

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,6 +8,7 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
+    coderay (1.1.2)
     colorator (1.1.0)
     colored (1.2)
     concurrent-ruby (1.0.5)
@@ -57,6 +58,7 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
     mercenary (0.3.6)
+    method_source (0.8.2)
     mini_portile2 (2.2.0)
     minitest (5.10.3)
     mr_poole (0.8.0)
@@ -65,6 +67,10 @@ GEM
     parallel (1.12.0)
     pathutil (0.14.0)
       forwardable-extended (~> 2.6)
+    pry (0.10.4)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
     public_suffix (3.0.0)
     rack (1.6.8)
     rack-jekyll (0.5.0)
@@ -82,6 +88,7 @@ GEM
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
+    slop (3.6.0)
     temple (0.8.0)
     thread_safe (0.3.6)
     tilt (2.0.8)
@@ -101,6 +108,7 @@ DEPENDENCIES
   jekyll-haml
   jekyll-sass
   mr_poole
+  pry
   rack-jekyll
   rake
 

--- a/_plugins/nodes_geojson.rb
+++ b/_plugins/nodes_geojson.rb
@@ -1,0 +1,6 @@
+Jekyll::Hooks.register :site, :post_write do |site|
+  src = [site.config["source"], "node-data", "nodes.json"].join File::Separator
+  dest = [site.config["destination"], "node-data", "nodes.geojson"].join File::Separator
+  puts "Rendering #{src} to #{dest}"
+  `_script/pittmesh_nodes_to_geojson.sh #{src} > #{dest}`
+end


### PR DESCRIPTION
Right now, it just calls out to the shell script, so the jq buildpack is still
necessary. At least we'll have something that *should* work on Heroku now.