### PR TITLE
Revert "Adds Grafana current users widget to homepage"

### DIFF
--- a/index.md
+++ b/index.md
@@ -14,5 +14,3 @@ PittMesh currently has <span id="live">#</span> live sites (<img alt="Live sites
 
 Want to help build the future of connectivity in Pittsburgh?
 [Contact Meta Mesh.](http://www.metamesh.org/#!contact-meta-mesh/c24vq)
-
-<iframe src="https://grafana.metamesh.org/dashboard-solo/db/pittmesh?theme=light&amp;panelId=3" width="200" height="100" frameborder="0" style="opacity:0.6"></iframe>


### PR DESCRIPTION
This reverts commit 2cc865ebd7bf33e1aec362b0f86fb4522a868306.

This is not ready because Grafana is still not publicly accessible in any way.